### PR TITLE
Fix typo in 3-4-3-PTQ

### DIFF
--- a/3-4-3-PTQ.ipynb
+++ b/3-4-3-PTQ.ipynb
@@ -253,7 +253,7 @@
         "\n",
         "Note: We however do not save a perfect factor of 4 in total memory usage as we now also have to store the scale (and potentially other factors needed to properly convert the numbers).\n",
         "\n",
-        "Lets explore this again looking at the files sizes of the MNIST model."
+        "Lets explore this again looking at the file sizes of the MNIST model."
       ]
     },
     {


### PR DESCRIPTION
This commit fixes a typo within the last sentence of the section under **_Exploring Post Training Quantization using TFLite_** title in the 3-4-3-PTQ.ipynb file.